### PR TITLE
Fixing refresh credits page 404 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bank-of-react",
   "version": "0.1.0",
   "homepage": "https://Krinap2003.github.io/bank-of-react-starter-code/",
+  "creditpage": "https://Krinap2003.github.io/bank-of-react-starter-code/credits",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",


### PR DESCRIPTION
When you refresh the credits page, there's a 404 error. Fixing that.